### PR TITLE
Junit errors

### DIFF
--- a/src/main/scala/org/specs/runner/JUnit.scala
+++ b/src/main/scala/org/specs/runner/JUnit.scala
@@ -241,13 +241,14 @@ case class UserError(t: Throwable, context: String) extends Throwable {
   }
 }
 
-case class SpecsComparisonFailure(expected: String, actual: String) extends ComparisonFailure("\nExpected: \"%s\"\n     got: \"%s\"\n" format (expected, actual), actual, expected)
+case class SpecsComparisonFailure(original: Throwable, expected: String, actual: String)
+  extends ComparisonFailure("\nExpected: \"%s\"\n     got: \"%s\"\n" format (expected, actual), actual, expected) with ThrowableProxy
 
 object SpecFailedError {
   val COMPARISON = "'([^']*)' is not equal to '([^']*)'".r
 
   def apply(failure: FailureException, context: String): AssertionFailedError = failure.getMessage match {
-    case msg@COMPARISON(actual, expected) => MyComparisonFailure(expected, actual)
+    case msg@COMPARISON(actual, expected) => SpecsComparisonFailure(failure, expected, actual)
     case msg@_ => new SpecAssertionFailedError(UserError(failure, context))
   }
 }

--- a/src/main/scala/org/specs/runner/JUnitSuiteRunner.scala
+++ b/src/main/scala/org/specs/runner/JUnitSuiteRunner.scala
@@ -167,12 +167,14 @@ class OldTestClassAdaptingListener(notifier: RunNotifier)  extends TestListener 
    */
   def addFailure(test: Test, t: AssertionFailedError) = {
     t match {
+      case SpecsComparisonFailure(expected, actual) => addNewFailure(test, new org.junit.ComparisonFailure(t.getMessage, expected, actual))
       // unfortunately the skip message can not be included for display in a description object
       // otherwise the description created when running the test and the description creating when
       // parsing the whole suite for the first time will not match
       case skipped: SkippedAssertionError => {
         notifier.fireTestIgnored(makeDescription(test))
       }
+      case e: SpecAssertionFailedError => addNewFailure(test, e.asAssertionError)
       case _ => addNewFailure(test, t)
     }
   }

--- a/src/main/scala/org/specs/runner/JUnitSuiteRunner.scala
+++ b/src/main/scala/org/specs/runner/JUnitSuiteRunner.scala
@@ -167,7 +167,8 @@ class OldTestClassAdaptingListener(notifier: RunNotifier)  extends TestListener 
    */
   def addFailure(test: Test, t: AssertionFailedError) = {
     t match {
-      case SpecsComparisonFailure(expected, actual) => addNewFailure(test, new org.junit.ComparisonFailure(t.getMessage, expected, actual))
+      case SpecsComparisonFailure(orig, expected, actual) =>
+        addNewFailure(test, new org.junit.ComparisonFailure(t.getMessage, expected, actual) with ThrowableProxy { def original = orig } )
       // unfortunately the skip message can not be included for display in a description object
       // otherwise the description created when running the test and the description creating when
       // parsing the whole suite for the first time will not match


### PR DESCRIPTION
I tried to improve the integration with JUnit here:
- when a failure occurs from a failing 'be_==' matcher, throw a ComparisonFailure
- for JUnit 4 repackage Assertions to use JUnit 4 ones, which inherit from java.lang.AssertionError

The basic target for this change is better integration with JUnit runners. Specifically, I made these changes with view on the IntelliJ JUnit runner, which with this changes is able to
1. show failures as failures not as errors
2. show the diff-GUI if a simple string comparison fails
