### PR TITLE
Fix for #180 + another small one

### DIFF
--- a/src/main/scala/org/specs/specification/Scalacheck.scala
+++ b/src/main/scala/org/specs/specification/Scalacheck.scala
@@ -96,31 +96,27 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                                                     a2: Arbitrary[A2],
                                                     s1: Shrink[A1], 
                                                     s2: Shrink[A2]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, P](f: AnyWithParameters[(A1, A2) => Boolean])(implicit 
-                                                         p: P => Prop,
+     def verifies[A1, A2](f: AnyWithParameters[(A1, A2) => Boolean])(implicit 
                                                          a1: Arbitrary[A1], 
                                                          a2: Arbitrary[A2],
                                                          s1: Shrink[A1], 
                                                          s2: Shrink[A2]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, P](f: (A1, A2, A3) => Boolean)(implicit 
-                                                          p: P => Prop,
+     def verifies[A1, A2, A3](f: (A1, A2, A3) => Boolean)(implicit 
                                                           a1: Arbitrary[A1], 
                                                           a2: Arbitrary[A2], 
                                                           a3: Arbitrary[A3],
                                                           s1: Shrink[A1], 
                                                           s2: Shrink[A2], 
                                                           s3: Shrink[A3]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, P](f: AnyWithParameters[(A1, A2, A3) => Boolean])(implicit 
-                                                                               p: P => Prop,
-                                                                               a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3](f: AnyWithParameters[(A1, A2, A3) => Boolean])(implicit 
+                                                                               a1: Arbitrary[A1],
                                                                                a2: Arbitrary[A2], 
                                                                                a3: Arbitrary[A3],
                                                                                s1: Shrink[A1], 
                                                                                s2: Shrink[A2],	 
                                                                                s3: Shrink[A3]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, P](f: (A1, A2, A3, A4) => Boolean)(implicit 
-                                                          p: P => Prop,
-                                                                  a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3, A4](f: (A1, A2, A3, A4) => Boolean)(implicit 
+                                                                  a1: Arbitrary[A1],
                                                                   a2: Arbitrary[A2], 
                                                                   a3: Arbitrary[A3],
                                                                   a4: Arbitrary[A4],
@@ -128,9 +124,8 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                                                                   s2: Shrink[A2], 
                                                                   s3: Shrink[A3], 
                                                                   s4: Shrink[A4]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4, P](f: AnyWithParameters[(A1, A2, A3, A4) => Boolean])(implicit 
-                                                                                     p: P => Prop,
-                                                                                     a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3, A4](f: AnyWithParameters[(A1, A2, A3, A4) => Boolean])(implicit 
+                                                                                     a1: Arbitrary[A1],
                                                                                      a2: Arbitrary[A2], 
                                                                                      a3: Arbitrary[A3],
                                                                                      a4: Arbitrary[A4],
@@ -138,9 +133,8 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                                                                                      s2: Shrink[A2], 
                                                                                      s3: Shrink[A3], 
                                                                                      s4: Shrink[A4]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5, P](f: (A1, A2, A3, A4, A5) => Boolean)(implicit 
-                                                             p: P => Prop,
-                                                             a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3, A4, A5](f: (A1, A2, A3, A4, A5) => Boolean)(implicit 
+                                                             a1: Arbitrary[A1],
                                                              a2: Arbitrary[A2], 
                                                              a3: Arbitrary[A3],
                                                              a4: Arbitrary[A4],
@@ -150,9 +144,8 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                                                              s3: Shrink[A3], 
                                                              s4: Shrink[A4], 
                                                              s5: Shrink[A5]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4, A5, P](f: AnyWithParameters[(A1, A2, A3, A4, A5) => Boolean])(implicit 
-                                                             p: P => Prop,
-                                                             a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3, A4, A5](f: AnyWithParameters[(A1, A2, A3, A4, A5) => Boolean])(implicit 
+                                                             a1: Arbitrary[A1],
                                                              a2: Arbitrary[A2], 
                                                              a3: Arbitrary[A3],
                                                              a4: Arbitrary[A4],
@@ -188,9 +181,8 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                                                              s4: Shrink[A4], 
                                                              s5: Shrink[A5], 
                                                              s6: Shrink[A6]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5, A6, A7, P](f: (A1, A2, A3, A4, A5, A6, A7) => Boolean)(implicit 
-                                                          p: P => Prop,
-                                                          a1: Arbitrary[A1], 
+     def verifies[A1, A2, A3, A4, A5, A6, A7](f: (A1, A2, A3, A4, A5, A6, A7) => Boolean)(implicit 
+                                                          a1: Arbitrary[A1],
                                                           a2: Arbitrary[A2], 
                                                           a3: Arbitrary[A3],
                                                           a4: Arbitrary[A4],

--- a/src/main/scala/org/specs/specification/Scalacheck.scala
+++ b/src/main/scala/org/specs/specification/Scalacheck.scala
@@ -85,166 +85,101 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
    * Class supporting the verification of a function with ScalaCheck, up to 6 parameters.
    */
   case class VerifiableExpectation(e: String) {
-     def verifies[A1](f: (A1) => Boolean)(implicit a1: Arbitrary[A1],
-                                             s1: Shrink[A1]) = forExample(e) in { Prop.forAll(f) must pass }     
-     def verifies[A1](f: AnyWithParameters[A1 => Boolean])(implicit 
-                                                          a1: Arbitrary[A1],
-                                                          s1: Shrink[A1]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
+    def verifies[A1: Arbitrary: Shrink](f: (A1) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink](f: AnyWithParameters[A1 => Boolean]) =
+      forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
      
-     def verifies[A1, A2](f: (A1, A2) => Boolean)(implicit 
-                                                    a1: Arbitrary[A1], 
-                                                    a2: Arbitrary[A2],
-                                                    s1: Shrink[A1], 
-                                                    s2: Shrink[A2]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2](f: AnyWithParameters[(A1, A2) => Boolean])(implicit 
-                                                         a1: Arbitrary[A1], 
-                                                         a2: Arbitrary[A2],
-                                                         s1: Shrink[A1], 
-                                                         s2: Shrink[A2]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3](f: (A1, A2, A3) => Boolean)(implicit 
-                                                          a1: Arbitrary[A1], 
-                                                          a2: Arbitrary[A2], 
-                                                          a3: Arbitrary[A3],
-                                                          s1: Shrink[A1], 
-                                                          s2: Shrink[A2], 
-                                                          s3: Shrink[A3]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3](f: AnyWithParameters[(A1, A2, A3) => Boolean])(implicit 
-                                                                               a1: Arbitrary[A1],
-                                                                               a2: Arbitrary[A2], 
-                                                                               a3: Arbitrary[A3],
-                                                                               s1: Shrink[A1], 
-                                                                               s2: Shrink[A2],	 
-                                                                               s3: Shrink[A3]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4](f: (A1, A2, A3, A4) => Boolean)(implicit 
-                                                                  a1: Arbitrary[A1],
-                                                                  a2: Arbitrary[A2], 
-                                                                  a3: Arbitrary[A3],
-                                                                  a4: Arbitrary[A4],
-                                                                  s1: Shrink[A1], 
-                                                                  s2: Shrink[A2], 
-                                                                  s3: Shrink[A3], 
-                                                                  s4: Shrink[A4]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4](f: AnyWithParameters[(A1, A2, A3, A4) => Boolean])(implicit 
-                                                                                     a1: Arbitrary[A1],
-                                                                                     a2: Arbitrary[A2], 
-                                                                                     a3: Arbitrary[A3],
-                                                                                     a4: Arbitrary[A4],
-                                                                                     s1: Shrink[A1], 
-                                                                                     s2: Shrink[A2], 
-                                                                                     s3: Shrink[A3], 
-                                                                                     s4: Shrink[A4]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5](f: (A1, A2, A3, A4, A5) => Boolean)(implicit 
-                                                             a1: Arbitrary[A1],
-                                                             a2: Arbitrary[A2], 
-                                                             a3: Arbitrary[A3],
-                                                             a4: Arbitrary[A4],
-                                                             a5: Arbitrary[A5],
-                                                             s1: Shrink[A1], 
-                                                             s2: Shrink[A2], 
-                                                             s3: Shrink[A3], 
-                                                             s4: Shrink[A4], 
-                                                             s5: Shrink[A5]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4, A5](f: AnyWithParameters[(A1, A2, A3, A4, A5) => Boolean])(implicit 
-                                                             a1: Arbitrary[A1],
-                                                             a2: Arbitrary[A2], 
-                                                             a3: Arbitrary[A3],
-                                                             a4: Arbitrary[A4],
-                                                             a5: Arbitrary[A5],
-                                                             s1: Shrink[A1], 
-                                                             s2: Shrink[A2], 
-                                                             s3: Shrink[A3], 
-                                                             s4: Shrink[A4], 
-                                                             s5: Shrink[A5]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5, A6](f: (A1, A2, A3, A4, A5, A6) => Boolean)(implicit 
-                                                          a1: Arbitrary[A1], 
-                                                          a2: Arbitrary[A2], 
-                                                          a3: Arbitrary[A3],
-                                                          a4: Arbitrary[A4],
-                                                          a5: Arbitrary[A5],
-                                                          a6: Arbitrary[A6],
-                                                          s1: Shrink[A1], 
-                                                          s2: Shrink[A2], 
-                                                          s3: Shrink[A3], 
-                                                          s4: Shrink[A4], 
-                                                          s5: Shrink[A5], 
-                                                          s6: Shrink[A6]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4, A5, A6](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6) => Boolean])(implicit 
-                                                             a1: Arbitrary[A1], 
-                                                             a2: Arbitrary[A2], 
-                                                             a3: Arbitrary[A3],
-                                                             a4: Arbitrary[A4],
-                                                             a5: Arbitrary[A5],
-                                                             a6: Arbitrary[A6],
-                                                             s1: Shrink[A1], 
-                                                             s2: Shrink[A2], 
-                                                             s3: Shrink[A3], 
-                                                             s4: Shrink[A4], 
-                                                             s5: Shrink[A5], 
-                                                             s6: Shrink[A6]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5, A6, A7](f: (A1, A2, A3, A4, A5, A6, A7) => Boolean)(implicit 
-                                                          a1: Arbitrary[A1],
-                                                          a2: Arbitrary[A2], 
-                                                          a3: Arbitrary[A3],
-                                                          a4: Arbitrary[A4],
-                                                          a5: Arbitrary[A5],
-                                                          a6: Arbitrary[A6],
-                                                          a7: Arbitrary[A7],
-                                                          s1: Shrink[A1], 
-                                                          s2: Shrink[A2], 
-                                                          s3: Shrink[A3], 
-                                                          s4: Shrink[A4], 
-                                                          s5: Shrink[A5], 
-                                                          s6: Shrink[A6],
-                                                          s7: Shrink[A7]) = forExample(e) in { Prop.forAll(f) must pass }
-     def verifies[A1, A2, A3, A4, A5, A6, A7](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7) => Boolean])(implicit 
-                                                             a1: Arbitrary[A1], 
-                                                             a2: Arbitrary[A2], 
-                                                             a3: Arbitrary[A3],
-                                                             a4: Arbitrary[A4],
-                                                             a5: Arbitrary[A5],
-                                                             a6: Arbitrary[A6],
-                                                             a7: Arbitrary[A7],
-                                                             s1: Shrink[A1], 
-                                                             s2: Shrink[A2], 
-                                                             s3: Shrink[A3], 
-                                                             s4: Shrink[A4], 
-                                                             s5: Shrink[A5], 
-                                                             s6: Shrink[A6],
-                                                             s7: Shrink[A7]) = forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
-     def verifies[A1, A2, A3, A4, A5, A6, A7, A8](f: (A1, A2, A3, A4, A5, A6, A7, A8) => Boolean)(implicit 
-                                                          a1: Arbitrary[A1], 
-                                                          a2: Arbitrary[A2], 
-                                                          a3: Arbitrary[A3],
-                                                          a4: Arbitrary[A4],
-                                                          a5: Arbitrary[A5],
-                                                          a6: Arbitrary[A6],
-                                                          a7: Arbitrary[A7],
-                                                          a8: Arbitrary[A8],
-                                                          s1: Shrink[A1], 
-                                                          s2: Shrink[A2], 
-                                                          s3: Shrink[A3], 
-                                                          s4: Shrink[A4], 
-                                                          s5: Shrink[A5], 
-                                                          s6: Shrink[A6],
-                                                          s7: Shrink[A7],
-                                                          s8: Shrink[A8]) = forExample(e) in { theValue(Prop.forAll(f)).must(pass) }
-     def verifies[A1, A2, A3, A4, A5, A6, A7, A8](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7, A8) => Boolean])(implicit 
-                                                             a1: Arbitrary[A1], 
-                                                             a2: Arbitrary[A2], 
-                                                             a3: Arbitrary[A3],
-                                                             a4: Arbitrary[A4],
-                                                             a5: Arbitrary[A5],
-                                                             a6: Arbitrary[A6],
-                                                             a7: Arbitrary[A7],
-                                                             a8: Arbitrary[A8],
-                                                             s1: Shrink[A1], 
-                                                             s2: Shrink[A2], 
-                                                             s3: Shrink[A3], 
-                                                             s4: Shrink[A4], 
-                                                             s5: Shrink[A5], 
-                                                             s6: Shrink[A6],
-                                                             s7: Shrink[A7],
-                                                             s8: Shrink[A8]) = forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink](f: (A1, A2) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2) => Boolean]) =
+      forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink](f: (A1, A2, A3) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink](f: (A1, A2, A3, A4) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6, A7) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink,
+                 A8: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6, A7, A8) => Boolean) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink,
+                 A8: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7, A8) => Boolean]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
    }
 
 }

--- a/src/main/scala/org/specs/specification/Scalacheck.scala
+++ b/src/main/scala/org/specs/specification/Scalacheck.scala
@@ -85,64 +85,49 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
    * Class supporting the verification of a function with ScalaCheck, up to 6 parameters.
    */
   case class VerifiableExpectation(e: String) {
-    def verifies[A1: Arbitrary: Shrink](f: (A1) => Boolean) =
+    def verifies[A1: Arbitrary: Shrink, P <% Prop](f: (A1) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
-    def verifies[A1: Arbitrary: Shrink](f: AnyWithParameters[A1 => Boolean]) =
+    def verifies[A1: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[A1 => P]) =
       forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
      
     def verifies[A1: Arbitrary: Shrink,
-                 A2: Arbitrary: Shrink](f: (A1, A2) => Boolean) =
+                 A2: Arbitrary: Shrink, P <% Prop](f: (A1, A2) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
     def verifies[A1: Arbitrary: Shrink,
-                 A2: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2) => Boolean]) =
+                 A2: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2) => P]) =
       forExample(e) in { Prop.forAll(f.function) must pass(f.params) }
 
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
-                 A3: Arbitrary: Shrink](f: (A1, A2, A3) => Boolean) =
+                 A3: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
-                 A3: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3) => Boolean]) =
+                 A3: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3) => P]) =
       forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
 
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
-                 A4: Arbitrary: Shrink](f: (A1, A2, A3, A4) => Boolean) =
+                 A4: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3, A4) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
-                 A4: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4) => Boolean]) =
-      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
-
-    def verifies[A1: Arbitrary: Shrink,
-                 A2: Arbitrary: Shrink,
-                 A3: Arbitrary: Shrink,
-                 A4: Arbitrary: Shrink,
-                 A5: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5) => Boolean) =
-      forExample(e) in { Prop.forAll(f) must pass }
-    def verifies[A1: Arbitrary: Shrink,
-                 A2: Arbitrary: Shrink,
-                 A3: Arbitrary: Shrink,
-                 A4: Arbitrary: Shrink,
-                 A5: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5) => Boolean]) =
+                 A4: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3, A4) => P]) =
       forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
 
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
                  A4: Arbitrary: Shrink,
-                 A5: Arbitrary: Shrink,
-                 A6: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6) => Boolean) =
+                 A5: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3, A4, A5) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
                  A4: Arbitrary: Shrink,
-                 A5: Arbitrary: Shrink,
-                 A6: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6) => Boolean]) =
+                 A5: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3, A4, A5) => P]) =
       forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
 
     def verifies[A1: Arbitrary: Shrink,
@@ -150,16 +135,14 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                  A3: Arbitrary: Shrink,
                  A4: Arbitrary: Shrink,
                  A5: Arbitrary: Shrink,
-                 A6: Arbitrary: Shrink,
-                 A7: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6, A7) => Boolean) =
+                 A6: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3, A4, A5, A6) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
                  A4: Arbitrary: Shrink,
                  A5: Arbitrary: Shrink,
-                 A6: Arbitrary: Shrink,
-                 A7: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7) => Boolean]) =
+                 A6: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6) => P]) =
       forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
 
     def verifies[A1: Arbitrary: Shrink,
@@ -168,9 +151,17 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                  A4: Arbitrary: Shrink,
                  A5: Arbitrary: Shrink,
                  A6: Arbitrary: Shrink,
-                 A7: Arbitrary: Shrink,
-                 A8: Arbitrary: Shrink](f: (A1, A2, A3, A4, A5, A6, A7, A8) => Boolean) =
+                 A7: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3, A4, A5, A6, A7) => P) =
       forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7) => P]) =
+      forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
+
     def verifies[A1: Arbitrary: Shrink,
                  A2: Arbitrary: Shrink,
                  A3: Arbitrary: Shrink,
@@ -178,7 +169,16 @@ trait ScalaCheckVerifications { outer: ExpectableFactory with BaseSpecification 
                  A5: Arbitrary: Shrink,
                  A6: Arbitrary: Shrink,
                  A7: Arbitrary: Shrink,
-                 A8: Arbitrary: Shrink](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7, A8) => Boolean]) =
+                 A8: Arbitrary: Shrink, P <% Prop](f: (A1, A2, A3, A4, A5, A6, A7, A8) => P) =
+      forExample(e) in { Prop.forAll(f) must pass }
+    def verifies[A1: Arbitrary: Shrink,
+                 A2: Arbitrary: Shrink,
+                 A3: Arbitrary: Shrink,
+                 A4: Arbitrary: Shrink,
+                 A5: Arbitrary: Shrink,
+                 A6: Arbitrary: Shrink,
+                 A7: Arbitrary: Shrink,
+                 A8: Arbitrary: Shrink, P <% Prop](f: AnyWithParameters[(A1, A2, A3, A4, A5, A6, A7, A8) => P]) =
       forExample(e) in { theValue(Prop.forAll(f.function)).must(pass(f.params)) }
    }
 

--- a/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
+++ b/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
@@ -112,7 +112,16 @@ class scalacheckMatchersSpec extends MatchersSpecification with ScalaCheckExampl
     }
   }
   "Functions" can {
-    "be checked directly, without creating an example, using the verifies operator. startsWith" verifies { (a: String, b: String) => (a+b).startsWith(a) }
+    "be checked directly, without creating an example, using the verifies operator." in {
+      "with 1 argument" verifies { (a: String) => a.startsWith(a.substring(0, math.min(0, a.length))) }
+      "with 2 arguments" verifies { (a: String, b: String) => (a+b).startsWith(a) }
+      "with 3 arguments" verifies { (a: String, b: String, c: String) => (a+b+c).startsWith(a) }
+      "with 4 arguments" verifies { (a: String, b: String, c: String, d: String) => (a+b+c+d).startsWith(a) }
+      "with 5 arguments" verifies { (a: String, b: String, c: String, d: String, e: String) => (a+b+c+d+e).startsWith(a) }
+      "with 6 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String) => (a+b+c+d+e+f).startsWith(a) }
+      "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) }
+      "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) }
+    }
   }
 }
 object spec extends Specification with ScalaCheck {

--- a/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
+++ b/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
@@ -113,14 +113,27 @@ class scalacheckMatchersSpec extends MatchersSpecification with ScalaCheckExampl
   }
   "Functions" can {
     "be checked directly, without creating an example, using the verifies operator." in {
-      "with 1 argument" verifies { (a: String) => a.startsWith(a.substring(0, math.min(0, a.length))) }
-      "with 2 arguments" verifies { (a: String, b: String) => (a+b).startsWith(a) }
-      "with 3 arguments" verifies { (a: String, b: String, c: String) => (a+b+c).startsWith(a) }
-      "with 4 arguments" verifies { (a: String, b: String, c: String, d: String) => (a+b+c+d).startsWith(a) }
-      "with 5 arguments" verifies { (a: String, b: String, c: String, d: String, e: String) => (a+b+c+d+e).startsWith(a) }
-      "with 6 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String) => (a+b+c+d+e+f).startsWith(a) }
-      "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) }
-      "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) }
+      "without parameters" in {
+        "with 1 argument" verifies { (a: String) => a.startsWith(a.substring(0, math.min(0, a.length))) }
+        "with 2 arguments" verifies { (a: String, b: String) => (a+b).startsWith(a) }
+        "with 3 arguments" verifies { (a: String, b: String, c: String) => (a+b+c).startsWith(a) }
+        "with 4 arguments" verifies { (a: String, b: String, c: String, d: String) => (a+b+c+d).startsWith(a) }
+        "with 5 arguments" verifies { (a: String, b: String, c: String, d: String, e: String) => (a+b+c+d+e).startsWith(a) }
+        "with 6 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String) => (a+b+c+d+e+f).startsWith(a) }
+        "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) }
+        "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) }
+      }
+
+      "with parameters" in {
+        "with 1 argument" verifies { (a: String) => a.startsWith(a.substring(0, math.min(0, a.length))) }.set(minTestsOk->250)
+        "with 2 arguments" verifies { (a: String, b: String) => (a+b).startsWith(a) }.set(minTestsOk->250)
+        "with 3 arguments" verifies { (a: String, b: String, c: String) => (a+b+c).startsWith(a) }.set(minTestsOk->250)
+        "with 4 arguments" verifies { (a: String, b: String, c: String, d: String) => (a+b+c+d).startsWith(a) }.set(minTestsOk->250)
+        "with 5 arguments" verifies { (a: String, b: String, c: String, d: String, e: String) => (a+b+c+d+e).startsWith(a) }.set(minTestsOk->250)
+        "with 6 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String) => (a+b+c+d+e+f).startsWith(a) }.set(minTestsOk->250)
+        "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) }.set(minTestsOk->250)
+        "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) }.set(minTestsOk->250)
+      }
     }
   }
 }

--- a/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
+++ b/src/test/scala/org/specs/matcher/scalacheckMatchersSpec.scala
@@ -134,6 +134,17 @@ class scalacheckMatchersSpec extends MatchersSpecification with ScalaCheckExampl
         "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) }.set(minTestsOk->250)
         "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) }.set(minTestsOk->250)
       }
+
+      "with function returning a Prop" in {
+        "with 1 argument" verifies { (a: String) => a.startsWith(a.substring(0, math.min(0, a.length))) :| "startsWith" }
+        "with 2 arguments" verifies { (a: String, b: String) => (a+b).startsWith(a) :| "startsWith" }
+        "with 3 arguments" verifies { (a: String, b: String, c: String) => (a+b+c).startsWith(a) :| "startsWith" }
+        "with 4 arguments" verifies { (a: String, b: String, c: String, d: String) => (a+b+c+d).startsWith(a) :| "startsWith" }
+        "with 5 arguments" verifies { (a: String, b: String, c: String, d: String, e: String) => (a+b+c+d+e).startsWith(a) :| "startsWith" }
+        "with 6 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String) => (a+b+c+d+e+f).startsWith(a) :| "startsWith" }
+        "with 7 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String) => (a+b+c+d+e+f+g).startsWith(a) :| "startsWith" }
+        "with 8 arguments" verifies { (a: String, b: String, c: String, d: String, e: String, f: String, g: String, h: String) => (a+b+c+d+e+f+g+h).startsWith(a) :| "startsWith" }
+      }
     }
   }
 }


### PR DESCRIPTION
Hey Eric,

aside from [#180](http://code.google.com/p/specs/issues/detail?id=180), I fixed another thing we found: You couldn't use verifies if the condition returned a Prop, i.e. when you use any ScalaCheck magic like `:|` or `==>` inside the conditions to check, because then the complete condition is lifted to return a Prop itself. I fixed that in the last commit by readding the implicit view `P <% Prop` and require all the conditions to return a P instead of a Boolean. I added examples to the tests which check that verifies compiles for all the arities.
